### PR TITLE
Use cameras other that PS3 Eye

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ landmark_sess = onnxruntime.InferenceSession(f"models/pose_landmark_{model}_batc
 running = True
 
 #region Camera Initialization
-fps = settings.get("fps", 50)
+fps = settings.get("fps", 30)   #change default fps to 30
 res = (640, 480)
 
 cam_count = len(calib["cameras"])
@@ -60,7 +60,8 @@ cam_sync = threading.Event()
 # A cam_thread gets spun up for each camera for being able to fetch frames in parallel
 def cam_thread(id):
     while running:
-        frame = cameras[id].get_frame()
+        _, frame = cameras[id].read()   #.read() is general for both cv2 and ps eyes
+        frame = cv2.rotate(frame,2)     #rotate camera sideways, as that gives more vertical space. Should be a setting somewhere
         if settings.get("undistort", True):
             frame = cv2.undistort(frame, oncm[id][0], oncm[id][1], None, oncm[id][2])
         frame.flags.writeable = False

--- a/utils/vision.py
+++ b/utils/vision.py
@@ -10,6 +10,8 @@ with open("calib.json", "r") as f:
 def get_cam(type, id):
     if type == "PS3 Eye Camera":
         return camera.Camera(id, (640, 480), 50, camera.ps3eye_format.PS3EYE_FORMAT_BGR)
+    else:
+        return cv2.VideoCapture(id+700) #open camera at id with the directshow API (700). Note that same camera is not always on the same id, so this needs a better way.
 
 def _make_homogeneous_rep_matrix(R, t):
     P = np.zeros((4,4))


### PR DESCRIPTION
This PR is not really ready to merge, it just contains some changes that I did to the repository to get my setup working a while back. As I have seen some people interested in this project, I decided to PR the changes on the chance it may help someone in the future.

- It allows you to use any USB webcam
- Added some code to flip image 90°, to make it easier to see the entire body

To use the feature, change the PS Eye camera to Other when adding a new camera, then select the ID the camera is on. This will usualy be 0,1,2 etc... To prevent the camera from being rotated, remove the cv2.rotate lines after the .read() lines.

TODO:
- Better enumeration of cameras. Selecting the camera by ID sucks, you dont know which camera will it open until you try, and windows may just decide to change the ID sometime after which the program will crash on startup (since camera cannot be opened)
- fix visualization to work properly on different aspect ratios
- Probably other things. Its been a while since I last tried it...